### PR TITLE
Add optional Windows batch script to run assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ The bot runs on both Linux (Debian/Ubuntu) and Windows 10/11/Server. Use the pla
    python -m src.main --config config.yaml
    ```
 
+   On Windows you can optionally double-click or execute the provided `run_assistant.bat` script, which activates the local
+   virtual environment (if present) and launches the assistant with your `config.yaml` (or a path supplied as the first argument).
+
    At startup the assistant now performs a pre-flight check to confirm FFmpeg, the Opus codec, your Faster-Whisper model, and the
    Ollama endpoint are all available. Any missing dependency will raise a clear error before connecting to Discord.
 

--- a/run_assistant.bat
+++ b/run_assistant.bat
@@ -1,0 +1,34 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Determine project root based on script location
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR%"=="" set "SCRIPT_DIR=.\"
+
+REM Default configuration file path can be overridden by passing it as first argument
+set "CONFIG_FILE=%SCRIPT_DIR%config.yaml"
+if not "%~1"=="" (
+    set "CONFIG_FILE=%~1"
+) else (
+    if not exist "%CONFIG_FILE%" (
+        set "CONFIG_FILE=%SCRIPT_DIR%config.example.yaml"
+    )
+)
+
+if not exist "%CONFIG_FILE%" (
+    echo [ERROR] Could not find configuration file.
+    echo         Create config.yaml or pass a path as the first argument.
+    exit /b 1
+)
+
+REM Activate the local virtual environment if it exists
+set "VENV_ACTIVATE=%SCRIPT_DIR%.venv\Scripts\activate.bat"
+if exist "%VENV_ACTIVATE%" (
+    call "%VENV_ACTIVATE%"
+) else (
+    echo [INFO] No virtual environment found at .venv\Scripts\activate.bat. Using system Python.
+)
+
+python -m src.main --config "%CONFIG_FILE%"
+
+endlocal


### PR DESCRIPTION
## Summary
- add an optional `run_assistant.bat` helper script to activate the local virtual environment and launch the bot on Windows
- document the new batch script in the quick start instructions so Windows users can run the assistant more easily

## Testing
- not run (batch script only)


------
https://chatgpt.com/codex/tasks/task_e_68e02a1392cc832fbe287e7636d4ef60