### PR TITLE
Add helper script for downloading Faster-Whisper models

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The bot runs on both Linux (Debian/Ubuntu) and Windows 10/11/Server. Use the pla
 4. Download or generate the models referenced in the configuration:
 
    - **Ollama**: `ollama pull mistral` (or your preferred Hugging Face model)
-   - **Faster-Whisper**: download the model directory into `models/faster-whisper-medium` (or another path referenced in `config.yaml`)
+   - **Faster-Whisper**: run `python scripts/download_faster_whisper.py medium` to fetch the Medium checkpoint into `models/faster-whisper-medium` (pass a destination path as the second argument to change the location). Other sizes such as `small` or `large-v3` are supported—match the value you set in `config.yaml`.
    - **Kokoro**: follow the [Kokoro project](https://github.com/hexgrad/kokoro) instructions to place the pipeline weights in an accessible location. Reference the [VOICES.md table on Hugging Face](https://huggingface.co/hexgrad/Kokoro-82M/blob/main/VOICES.md) for valid speaker IDs.
 
 5. Run the bot:

--- a/docs/setup-linux.md
+++ b/docs/setup-linux.md
@@ -51,7 +51,7 @@ Update the Discord bot token, local model paths, and any voice or logging prefer
 ## 6. Prepare local AI services
 
 - **Ollama**: Install the [Linux release](https://ollama.ai/download) and run `ollama pull mistral` (or your preferred model).
-- **Faster-Whisper**: Download the desired model directory to the path referenced in `config.yaml` (for example `models/faster-whisper-medium`).
+- **Faster-Whisper**: Run `python scripts/download_faster_whisper.py medium` to place the Medium checkpoint in `models/faster-whisper-medium` (replace `medium` with the size you configured, or add a custom destination as the second argument).
 - **Kokoro voices**: Follow the [Kokoro instructions](https://github.com/hexgrad/kokoro) to download voices locally. Make sure the `voice` value in `config.yaml` matches an installed voice ID.
 
 ## 7. Launch the bot

--- a/docs/setup-windows.md
+++ b/docs/setup-windows.md
@@ -54,7 +54,7 @@ Update the Discord bot token, local model paths, and any voice or logging prefer
 ## 6. Prepare local AI services
 
 - **Ollama**: Install the [Windows release](https://ollama.ai/download) and run `ollama pull mistral` (or your preferred model) from a new terminal.
-- **Faster-Whisper**: Download the desired model directory and update `stt.model_path` in `config.yaml` to point at it.
+- **Faster-Whisper**: From the project directory run `python scripts/download_faster_whisper.py medium` to download the Medium checkpoint into `models\faster-whisper-medium`. Adjust the size (for example `small`, `large-v3`) or pass an explicit destination as needed and update `stt.model_path` accordingly.
 - **Kokoro voices**: Follow the [Kokoro instructions](https://github.com/hexgrad/kokoro) to download voices locally. Make sure the `voice` value in `config.yaml` matches an installed voice ID.
 
 ## 7. Launch the bot

--- a/scripts/download_faster_whisper.py
+++ b/scripts/download_faster_whisper.py
@@ -1,0 +1,91 @@
+"""Helper script to download Faster-Whisper models.
+
+Usage examples:
+
+    python scripts/download_faster_whisper.py medium models/faster-whisper-medium
+    python scripts/download_faster_whisper.py small
+
+The script wraps ``faster_whisper.download_model`` and ensures the target directory
+is created before download. The model is fetched from the Hugging Face Hub using
+Systran's pre-converted CTranslate2 checkpoints.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from faster_whisper import download_model
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download a Faster-Whisper model to a local directory.",
+    )
+    parser.add_argument(
+        "model",
+        help=(
+            "Model size or Hugging Face repo id to download (e.g. tiny, base, "
+            "small, medium, large-v3, Systran/faster-whisper-medium)"
+        ),
+    )
+    parser.add_argument(
+        "destination",
+        nargs="?",
+        default=None,
+        help=(
+            "Optional output directory. Defaults to models/<model> if omitted "
+            "and <model> is a known size."
+        ),
+    )
+    parser.add_argument(
+        "--cache-dir",
+        default=None,
+        help="Optional Hugging Face cache directory to reuse across runs.",
+    )
+    parser.add_argument(
+        "--local-files-only",
+        action="store_true",
+        help="Do not hit the network; only use existing cached files.",
+    )
+    parser.add_argument(
+        "--revision",
+        default=None,
+        help="Optional git revision (branch, tag, commit) to download.",
+    )
+    parser.add_argument(
+        "--use-auth-token",
+        default=None,
+        help="Optional Hugging Face auth token or True to use the stored token.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    destination: Path | None
+    if args.destination is not None:
+        destination = Path(args.destination)
+    else:
+        destination = Path("models") / f"faster-whisper-{args.model}"
+
+    if destination is not None:
+        destination.mkdir(parents=True, exist_ok=True)
+        output_dir = str(destination)
+    else:
+        output_dir = None
+
+    path = download_model(
+        args.model,
+        output_dir=output_dir,
+        local_files_only=args.local_files_only,
+        cache_dir=args.cache_dir,
+        revision=args.revision,
+        use_auth_token=args.use_auth_token,
+    )
+
+    print(f"Model downloaded to: {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small CLI helper that wraps faster_whisper.download_model
- document how to use the helper from the README and both setup guides so users can fetch models quickly

## Testing
- not run (documentation and helper script only)


------
https://chatgpt.com/codex/tasks/task_e_68e069292e00832fac820cf83fd1372f