### PR TITLE
Add Kokoro language configuration

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -47,6 +47,7 @@ kokoro:
   emotion: "neutral"
   output_dir: "tts_output"
   format: "wav"
+  lang_code: "en"  # See https://github.com/hexgrad/kokoro for supported language codes
 
 logging:
   level: "INFO"

--- a/src/ai/tts.py
+++ b/src/ai/tts.py
@@ -28,7 +28,7 @@ class TextToSpeech:
         output_dir.mkdir(parents=True, exist_ok=True)
         self._loop = asyncio.get_running_loop()
         _LOGGER.info("Initializing Kokoro pipeline with voice %s", config.voice)
-        self._pipeline = KPipeline()
+        self._pipeline = KPipeline(lang_code=config.lang_code)
 
     async def synthesize(self, text: str, filename: Optional[str] = None) -> Path:
         if not text:

--- a/src/config.py
+++ b/src/config.py
@@ -58,6 +58,7 @@ class KokoroConfig:
     emotion: str = "neutral"
     output_dir: str = "tts_output"
     format: str = "wav"
+    lang_code: str = "en"
 
 
 @dataclass
@@ -170,6 +171,7 @@ def load_config(path: Path | str) -> AppConfig:
             emotion=raw_config.get("kokoro", {}).get("emotion", "neutral"),
             output_dir=raw_config.get("kokoro", {}).get("output_dir", "tts_output"),
             format=raw_config.get("kokoro", {}).get("format", "wav"),
+            lang_code=raw_config.get("kokoro", {}).get("lang_code", "en"),
         ),
         logging=LoggingConfig(
             level=raw_config.get("logging", {}).get("level", "INFO"),


### PR DESCRIPTION
## Summary
- add support for configuring the Kokoro pipeline language code
- pass the configured language code when creating the text-to-speech pipeline
- document the new `lang_code` option in the example configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e070645318832fabb926c66e073e5f