### PR TITLE
Handle Kokoro language code aliases

### DIFF
--- a/src/ai/tts.py
+++ b/src/ai/tts.py
@@ -13,6 +13,8 @@ except ImportError as exc:  # pragma: no cover - dependency error
         "Install it from https://github.com/hexgrad/kokoro before running the bot."
     ) from exc
 
+from kokoro.pipeline import LANG_CODES  # type: ignore
+
 from ..config import KokoroConfig
 from ..logging_utils import get_logger
 
@@ -28,7 +30,8 @@ class TextToSpeech:
         output_dir.mkdir(parents=True, exist_ok=True)
         self._loop = asyncio.get_running_loop()
         _LOGGER.info("Initializing Kokoro pipeline with voice %s", config.voice)
-        self._pipeline = KPipeline(lang_code=config.lang_code)
+        lang_code = self._resolve_lang_code(config.lang_code)
+        self._pipeline = KPipeline(lang_code=lang_code)
 
     async def synthesize(self, text: str, filename: Optional[str] = None) -> Path:
         if not text:
@@ -55,6 +58,58 @@ class TextToSpeech:
         )
         _LOGGER.debug("Generated speech saved to %s", output_path)
         return output_path
+
+    @staticmethod
+    def _resolve_lang_code(configured_code: str) -> str:
+        normalized = configured_code.strip().lower().replace("_", "-")
+        if not normalized:
+            raise ValueError("Kokoro language code must be a non-empty string")
+
+        if normalized in LANG_CODES:
+            return normalized
+
+        alias_map = {
+            "en": "a",
+            "en-us": "a",
+            "english": "a",
+            "american-english": "a",
+            "en-gb": "b",
+            "british-english": "b",
+            "uk-english": "b",
+            "es": "e",
+            "es-es": "e",
+            "spanish": "e",
+            "fr": "f",
+            "fr-fr": "f",
+            "french": "f",
+            "hi": "h",
+            "hindi": "h",
+            "it": "i",
+            "italian": "i",
+            "pt": "p",
+            "pt-br": "p",
+            "portuguese": "p",
+            "pt-brasil": "p",
+            "ja": "j",
+            "jp": "j",
+            "japanese": "j",
+            "zh": "z",
+            "zh-cn": "z",
+            "mandarin": "z",
+            "chinese": "z",
+        }
+
+        if normalized in alias_map:
+            return alias_map[normalized]
+
+        for code, description in LANG_CODES.items():
+            if normalized == description.lower().replace("_", "-"):
+                return code
+
+        raise ValueError(
+            "Unsupported Kokoro language code '%s'. Supported codes are: %s"
+            % (configured_code, ", ".join(sorted(set(LANG_CODES) | set(alias_map.keys()))))
+        )
 
 
 __all__ = ["TextToSpeech"]


### PR DESCRIPTION
## Summary
- normalize Kokoro language codes before initializing the Kokoro pipeline
- support user-friendly aliases for Kokoro language selection and improve error messaging

## Testing
- python - <<'PY'
from src.ai.tts import TextToSpeech
print(TextToSpeech._resolve_lang_code('en'))
print(TextToSpeech._resolve_lang_code('en-gb'))
print(TextToSpeech._resolve_lang_code('fr'))
PY

------
https://chatgpt.com/codex/tasks/task_e_68e0719a14c8832f888fe3875a2f606b