### PR TITLE
Add compatibility shims for py-cord app commands

### DIFF
--- a/src/discord_bot.py
+++ b/src/discord_bot.py
@@ -8,13 +8,16 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 import discord
-from discord import app_commands
 from discord.ext import commands, tasks
 
 from .ai.conversation_manager import ConversationManager
 from .ai.voice_session import VoiceSession
 from .config import AppConfig
 from .logging_utils import get_logger
+from .discord_compat import ensure_app_commands_ready
+
+ensure_app_commands_ready(raise_on_failure=True)
+from discord import app_commands
 
 _LOGGER = get_logger(__name__)
 
@@ -47,6 +50,8 @@ class DiscordAssistantBot(commands.Bot):
         self.config_data = config
         self.conversation_manager = conversation_manager
         self.voice_session = voice_session
+        if not hasattr(self, "tree"):
+            self.tree = app_commands.CommandTree(self)
         self._status_index = 0
         self._voice_states: Dict[int, WakeConversationState] = {}
         self._wake_cooldowns: Dict[int, float] = {}

--- a/src/discord_compat.py
+++ b/src/discord_compat.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+import importlib
+from enum import Enum
+from typing import ClassVar, Iterable, List, Optional, Sequence
+
+from .logging_utils import get_logger
+
+_LOGGER = get_logger(__name__)
+
+_REQUIRED_ATTRIBUTES = {
+    "Command": ("discord.app_commands", "discord.app_commands.commands"),
+    "describe": ("discord.app_commands", "discord.app_commands.decorators"),
+    "guild_only": ("discord.app_commands", "discord.app_commands.decorators"),
+}
+
+
+def ensure_app_commands_ready(*, raise_on_failure: bool = False) -> bool:
+    """Ensure ``discord.app_commands`` is importable and has the expected helpers.
+
+    Parameters
+    ----------
+    raise_on_failure:
+        If ``True`` then :class:`RuntimeError` is raised when the module cannot be
+        prepared. Otherwise the failure is logged and ``False`` is returned.
+    """
+
+    import discord
+
+    _backfill_app_command_enums(discord)
+    _backfill_app_command_errors(discord)
+    _backfill_app_command_utils(discord)
+    _backfill_app_command_flags(discord)
+    _backfill_app_command_state(discord)
+
+    try:
+        app_commands = _import_app_commands(discord)
+    except Exception as exc:  # pragma: no cover - defensive guard for unexpected environments
+        _LOGGER.debug("Failed to import discord.app_commands", exc_info=exc)
+        if raise_on_failure:
+            raise RuntimeError("Unable to import discord.app_commands") from exc
+        return False
+
+    missing_attributes = _ensure_required_attributes(app_commands)
+    if missing_attributes:
+        message = (
+            "discord.app_commands is missing required features: "
+            + ", ".join(sorted(missing_attributes))
+        )
+        if raise_on_failure:
+            raise RuntimeError(message)
+        _LOGGER.debug(message)
+        return False
+
+    return True
+
+
+def _ensure_required_attributes(app_commands_module) -> Iterable[str]:
+    missing_attributes = []
+
+    for attribute, module_names in _REQUIRED_ATTRIBUTES.items():
+        if hasattr(app_commands_module, attribute):
+            continue
+
+        for module_name in module_names:
+            try:
+                module = importlib.import_module(module_name)
+            except (ImportError, AttributeError):  # pragma: no cover - defensive guard
+                continue
+
+            value = getattr(module, attribute, None)
+            if value is not None:
+                setattr(app_commands_module, attribute, value)
+                break
+        else:
+            missing_attributes.append(attribute)
+
+    return missing_attributes
+
+
+def _import_app_commands(discord_module: object):
+    try:
+        app_commands = getattr(discord_module, "app_commands")
+    except AttributeError:
+        app_commands = None
+
+    if app_commands is None:
+        app_commands = importlib.import_module("discord.app_commands")
+        setattr(discord_module, "app_commands", app_commands)
+
+    return app_commands
+
+
+def _backfill_app_command_enums(discord_module: object) -> None:
+    enums_module = getattr(discord_module, "enums", None)
+    if enums_module is None:
+        return
+
+    enum_base = getattr(enums_module, "Enum", Enum)
+
+    if not hasattr(enums_module, "Locale"):
+        class Locale(enum_base):  # type: ignore[misc,valid-type]
+            american_english = "en-US"
+            british_english = "en-GB"
+            bulgarian = "bg"
+            chinese = "zh-CN"
+            taiwan_chinese = "zh-TW"
+            croatian = "hr"
+            czech = "cs"
+            indonesian = "id"
+            danish = "da"
+            dutch = "nl"
+            finnish = "fi"
+            french = "fr"
+            german = "de"
+            greek = "el"
+            hindi = "hi"
+            hungarian = "hu"
+            italian = "it"
+            japanese = "ja"
+            korean = "ko"
+            latin_american_spanish = "es-419"
+            lithuanian = "lt"
+            norwegian = "no"
+            polish = "pl"
+            brazil_portuguese = "pt-BR"
+            romanian = "ro"
+            russian = "ru"
+            spain_spanish = "es-ES"
+            swedish = "sv-SE"
+            thai = "th"
+            turkish = "tr"
+            ukrainian = "uk"
+            vietnamese = "vi"
+
+            def __str__(self) -> str:
+                return self.value
+
+        setattr(enums_module, "Locale", Locale)
+
+    if not hasattr(enums_module, "AppCommandOptionType"):
+        slash_option = getattr(enums_module, "SlashCommandOptionType", None)
+        if slash_option is not None:
+            setattr(enums_module, "AppCommandOptionType", slash_option)
+        else:
+            class AppCommandOptionType(enum_base):  # type: ignore[misc,valid-type]
+                subcommand = 1
+                subcommand_group = 2
+                string = 3
+                integer = 4
+                boolean = 5
+                user = 6
+                channel = 7
+                role = 8
+                mentionable = 9
+                number = 10
+                attachment = 11
+
+            setattr(enums_module, "AppCommandOptionType", AppCommandOptionType)
+
+    if not hasattr(enums_module, "AppCommandType"):
+        class AppCommandType(enum_base):  # type: ignore[misc,valid-type]
+            chat_input = 1
+            user = 2
+            message = 3
+
+        setattr(enums_module, "AppCommandType", AppCommandType)
+
+    if not hasattr(enums_module, "AppCommandPermissionType"):
+        class AppCommandPermissionType(enum_base):  # type: ignore[misc,valid-type]
+            role = 1
+            user = 2
+            channel = 3
+
+        setattr(enums_module, "AppCommandPermissionType", AppCommandPermissionType)
+
+    channel_type = getattr(enums_module, "ChannelType", None)
+    if channel_type is not None and not hasattr(channel_type, "media"):
+        fallback = getattr(channel_type, "forum", None) or getattr(channel_type, "text", None)
+        if fallback is not None:
+            type.__setattr__(channel_type, "media", fallback)
+
+
+def _backfill_app_command_errors(discord_module: object) -> None:
+    errors_module = getattr(discord_module, "errors", None)
+    if errors_module is None:
+        return
+
+    if not hasattr(errors_module, "MissingApplicationID"):
+        base_exception = getattr(errors_module, "DiscordException", Exception)
+
+        class MissingApplicationID(base_exception):  # type: ignore[misc,valid-type]
+            """Raised when application ID dependent features are used without configuration."""
+
+            pass
+
+        setattr(errors_module, "MissingApplicationID", MissingApplicationID)
+
+
+def _backfill_app_command_utils(discord_module: object) -> None:
+    utils_module = getattr(discord_module, "utils", None)
+    if utils_module is None:
+        return
+
+    if not hasattr(utils_module, "_human_join"):
+        def _human_join(values, *, delimiter: str = ", ", final: str = " and ") -> str:
+            values = [str(value) for value in values if value is not None]
+            if not values:
+                return ""
+            if len(values) == 1:
+                return values[0]
+            if len(values) == 2:
+                return f"{values[0]}{final}{values[1]}"
+            return f"{delimiter.join(values[:-1])}{final}{values[-1]}"
+
+        setattr(utils_module, "_human_join", _human_join)
+
+    missing_sentinel = getattr(utils_module, "_MissingSentinel", None)
+    if missing_sentinel is not None and getattr(missing_sentinel, "__hash__", None) is None:
+        missing_sentinel.__hash__ = object.__hash__  # type: ignore[assignment]
+
+    if not hasattr(utils_module, "is_inside_class"):
+        def is_inside_class(func):
+            if getattr(func, "__qualname__", func.__name__) == func.__name__:
+                return False
+            remaining = func.__qualname__.rpartition(".")[0]
+            return not remaining.endswith("<locals>")
+
+        setattr(utils_module, "is_inside_class", is_inside_class)
+
+    if not hasattr(utils_module, "_shorten"):
+        from textwrap import TextWrapper
+        import re
+
+        _wrapper = TextWrapper(width=100, max_lines=1, replace_whitespace=True, placeholder="…")
+
+        def _shorten(text: str, *, _wrapper: TextWrapper = _wrapper) -> str:
+            parts = re.split(r"\n\s*\n", text, maxsplit=1)
+            text = parts[0]
+            return _wrapper.fill(" ".join(text.strip().split()))
+
+        setattr(utils_module, "_shorten", _shorten)
+
+    if not hasattr(utils_module, "_to_kebab_case"):
+        import re
+
+        pattern = re.compile(r"(?<!^)(?=[A-Z])")
+
+        def _to_kebab_case(text: str) -> str:
+            return pattern.sub("-", text).lower()
+
+        setattr(utils_module, "_to_kebab_case", _to_kebab_case)
+
+    if not hasattr(utils_module, "_is_submodule"):
+        def _is_submodule(parent: str, child: str) -> bool:
+            return parent == child or child.startswith(parent + ".")
+
+        setattr(utils_module, "_is_submodule", _is_submodule)
+
+
+def _backfill_app_command_flags(discord_module: object) -> None:
+    flags_module = getattr(discord_module, "flags", None)
+    if flags_module is None:
+        return
+
+    if not hasattr(flags_module, "AppInstallationType"):
+        class AppInstallationType:
+            __slots__ = ("_guild", "_user")
+            GUILD: ClassVar[int] = 0
+            USER: ClassVar[int] = 1
+
+            def __init__(self, *, guild: Optional[bool] = None, user: Optional[bool] = None):
+                self._guild = guild
+                self._user = user
+
+            def __repr__(self) -> str:  # pragma: no cover - debugging helper
+                return f"<AppInstallationType guild={self.guild!r} user={self.user!r}>"
+
+            @property
+            def guild(self) -> bool:
+                return bool(self._guild)
+
+            @guild.setter
+            def guild(self, value: bool) -> None:
+                self._guild = bool(value)
+
+            @property
+            def user(self) -> bool:
+                return bool(self._user)
+
+            @user.setter
+            def user(self, value: bool) -> None:
+                self._user = bool(value)
+
+            def merge(self, other: "AppInstallationType") -> "AppInstallationType":
+                guild = self._guild if other._guild is None else other._guild
+                user = self._user if other._user is None else other._user
+                return AppInstallationType(guild=guild, user=user)
+
+            def _is_unset(self) -> bool:
+                return self._guild is None and self._user is None
+
+            def _merge_to_array(self, other: Optional["AppInstallationType"]):
+                result = self.merge(other) if other is not None else self
+                if result._is_unset():
+                    return None
+                return result.to_array()
+
+            @classmethod
+            def _from_value(cls, value: Sequence[int]) -> "AppInstallationType":
+                self = cls()
+                for entry in value:
+                    if entry == cls.GUILD:
+                        self._guild = True
+                    elif entry == cls.USER:
+                        self._user = True
+                return self
+
+            def to_array(self) -> List[int]:
+                values: List[int] = []
+                if self._guild:
+                    values.append(self.GUILD)
+                if self._user:
+                    values.append(self.USER)
+                return values
+
+        setattr(flags_module, "AppInstallationType", AppInstallationType)
+
+    if not hasattr(flags_module, "AppCommandContext"):
+        class AppCommandContext:
+            __slots__ = ("_guild", "_dm_channel", "_private_channel")
+            GUILD: ClassVar[int] = 0
+            DM_CHANNEL: ClassVar[int] = 1
+            PRIVATE_CHANNEL: ClassVar[int] = 2
+
+            def __init__(
+                self,
+                *,
+                guild: Optional[bool] = None,
+                dm_channel: Optional[bool] = None,
+                private_channel: Optional[bool] = None,
+            ) -> None:
+                self._guild = guild
+                self._dm_channel = dm_channel
+                self._private_channel = private_channel
+
+            def __repr__(self) -> str:  # pragma: no cover - debugging helper
+                return (
+                    "<AppCommandContext "
+                    f"guild={self.guild!r} dm_channel={self.dm_channel!r} "
+                    f"private_channel={self.private_channel!r}>"
+                )
+
+            @property
+            def guild(self) -> bool:
+                return bool(self._guild)
+
+            @guild.setter
+            def guild(self, value: bool) -> None:
+                self._guild = bool(value)
+
+            @property
+            def dm_channel(self) -> bool:
+                return bool(self._dm_channel)
+
+            @dm_channel.setter
+            def dm_channel(self, value: bool) -> None:
+                self._dm_channel = bool(value)
+
+            @property
+            def private_channel(self) -> bool:
+                return bool(self._private_channel)
+
+            @private_channel.setter
+            def private_channel(self, value: bool) -> None:
+                self._private_channel = bool(value)
+
+            def merge(self, other: "AppCommandContext") -> "AppCommandContext":
+                guild = self._guild if other._guild is None else other._guild
+                dm_channel = self._dm_channel if other._dm_channel is None else other._dm_channel
+                private_channel = (
+                    self._private_channel
+                    if other._private_channel is None
+                    else other._private_channel
+                )
+                return AppCommandContext(
+                    guild=guild, dm_channel=dm_channel, private_channel=private_channel
+                )
+
+            def _is_unset(self) -> bool:
+                return (
+                    self._guild is None
+                    and self._dm_channel is None
+                    and self._private_channel is None
+                )
+
+            def _merge_to_array(self, other: Optional["AppCommandContext"]):
+                result = self.merge(other) if other is not None else self
+                if result._is_unset():
+                    return None
+                return result.to_array()
+
+            @classmethod
+            def _from_value(cls, value: Sequence[int]) -> "AppCommandContext":
+                self = cls()
+                for entry in value:
+                    if entry == cls.GUILD:
+                        self._guild = True
+                    elif entry == cls.DM_CHANNEL:
+                        self._dm_channel = True
+                    elif entry == cls.PRIVATE_CHANNEL:
+                        self._private_channel = True
+                return self
+
+            def to_array(self) -> List[int]:
+                values: List[int] = []
+                if self._guild:
+                    values.append(self.GUILD)
+                if self._dm_channel:
+                    values.append(self.DM_CHANNEL)
+                if self._private_channel:
+                    values.append(self.PRIVATE_CHANNEL)
+                return values
+
+        setattr(flags_module, "AppCommandContext", AppCommandContext)
+
+
+def _backfill_app_command_state(discord_module: object) -> None:
+    state_module = getattr(discord_module, "state", None)
+    if state_module is None:
+        return
+
+    connection_state = getattr(state_module, "ConnectionState", None)
+    if connection_state is None:
+        return
+
+    if not hasattr(connection_state, "_command_tree"):
+        connection_state._command_tree = None  # type: ignore[attr-defined]
+
+
+__all__ = ["ensure_app_commands_ready"]
+

--- a/src/preflight.py
+++ b/src/preflight.py
@@ -9,6 +9,7 @@ import discord
 
 from .ai.ollama_client import OllamaClient
 from .config import AppConfig
+from .discord_compat import ensure_app_commands_ready
 from .logging_utils import get_logger
 
 _LOGGER = get_logger(__name__)
@@ -56,23 +57,13 @@ def _ensure_discord_sinks_available() -> None:
             "to enable voice capture."
         )
 
-    if not _app_command_support_available():
+    if not ensure_app_commands_ready():
         raise RuntimeError(
             "discord.app_commands is missing required features (Command, describe, or guild_only)."
             " Install or update 'py-cord[voice]==2.6.1' to enable slash command support."
         )
 
     _LOGGER.debug("discord voice sinks and enums are available")
-
-
-def _app_command_support_available() -> bool:
-    try:
-        from discord import app_commands as _app_commands  # type: ignore
-    except (ImportError, AttributeError):
-        return False
-
-    required_attributes = ("Command", "describe", "guild_only")
-    return all(hasattr(_app_commands, attr) for attr in required_attributes)
 
 
 def _ensure_stt_assets(config: AppConfig) -> None:

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -6,6 +6,7 @@ import types
 from pathlib import Path
 
 import pytest
+from enum import Enum as PyEnum
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
@@ -13,7 +14,10 @@ if str(PROJECT_ROOT) not in sys.path:
 
 
 def _install_discord_stub(
-    monkeypatch: pytest.MonkeyPatch, *, app_commands: types.ModuleType | None = None
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    app_commands: types.ModuleType | None = None,
+    enums: types.ModuleType | None = None,
 ) -> None:
     for module_name in list(sys.modules):
         if module_name == "discord" or module_name.startswith("discord."):
@@ -23,7 +27,9 @@ def _install_discord_stub(
     fake_opus = types.SimpleNamespace(is_loaded=lambda: True, load_opus=lambda _: None)
     fake_sinks = types.ModuleType("discord.sinks")
     fake_sinks.WaveSink = object()
-    fake_enums = types.ModuleType("discord.enums")
+    fake_enums = enums or types.ModuleType("discord.enums")
+    if not hasattr(fake_enums, "Enum"):
+        fake_enums.Enum = PyEnum
 
     fake_discord.opus = fake_opus
     fake_discord.sinks = fake_sinks
@@ -40,6 +46,7 @@ def _install_discord_stub(
 
 def test_missing_app_command_support_surfaces_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_discord_stub(monkeypatch)
+    sys.modules.pop("src.discord_compat", None)
     sys.modules.pop("src.preflight", None)
     preflight = importlib.import_module("src.preflight")
 
@@ -59,6 +66,7 @@ def test_app_command_support_with_required_attributes_passes(monkeypatch: pytest
     fake_app_commands.guild_only = lambda: None
 
     _install_discord_stub(monkeypatch, app_commands=fake_app_commands)
+    sys.modules.pop("src.discord_compat", None)
     sys.modules.pop("src.preflight", None)
     preflight = importlib.import_module("src.preflight")
 
@@ -66,3 +74,102 @@ def test_app_command_support_with_required_attributes_passes(monkeypatch: pytest
         preflight._ensure_discord_sinks_available()
     finally:
         sys.modules.pop("src.preflight", None)
+
+
+def test_app_command_support_can_patch_missing_attributes(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_app_commands = types.ModuleType("discord.app_commands")
+    fake_commands_module = types.ModuleType("discord.app_commands.commands")
+    fake_commands_module.Command = object()
+    fake_decorators_module = types.ModuleType("discord.app_commands.decorators")
+    fake_decorators_module.describe = lambda **_: None
+    fake_decorators_module.guild_only = lambda: None
+
+    _install_discord_stub(monkeypatch, app_commands=fake_app_commands)
+    monkeypatch.setitem(sys.modules, "discord.app_commands.commands", fake_commands_module)
+    monkeypatch.setitem(sys.modules, "discord.app_commands.decorators", fake_decorators_module)
+
+    sys.modules.pop("src.discord_compat", None)
+    sys.modules.pop("src.preflight", None)
+    preflight = importlib.import_module("src.preflight")
+
+    try:
+        preflight._ensure_discord_sinks_available()
+    finally:
+        sys.modules.pop("src.preflight", None)
+
+
+def test_app_command_support_backfills_pycord_enums(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_enums = types.ModuleType("discord.enums")
+    fake_enums.Enum = PyEnum
+    fake_enums.SlashCommandOptionType = PyEnum(
+        "SlashCommandOptionType",
+        {
+            "subcommand": 1,
+            "subcommand_group": 2,
+            "string": 3,
+            "integer": 4,
+            "boolean": 5,
+            "user": 6,
+            "channel": 7,
+            "role": 8,
+            "mentionable": 9,
+            "number": 10,
+            "attachment": 11,
+        },
+    )
+
+    _install_discord_stub(monkeypatch, enums=fake_enums)
+
+    fake_app_commands_package = types.ModuleType("discord.app_commands")
+    fake_app_commands_package.__path__ = []
+    fake_commands_module = types.ModuleType("discord.app_commands.commands")
+
+    class _FakeCommand:  # pragma: no cover - simple placeholder
+        pass
+
+    def _describe(**_: object):
+        from discord.enums import Locale  # type: ignore
+
+        _ = Locale.american_english
+
+        def decorator(func):
+            return func
+
+        return decorator
+
+    def _guild_only():
+        return _describe()
+
+    fake_commands_module.Command = _FakeCommand
+    fake_commands_module.describe = _describe
+    fake_commands_module.guild_only = _guild_only
+
+    fake_decorators_module = types.ModuleType("discord.app_commands.decorators")
+    fake_decorators_module.describe = _describe
+    fake_decorators_module.guild_only = _guild_only
+
+    monkeypatch.setitem(sys.modules, "discord.app_commands", fake_app_commands_package)
+    monkeypatch.setitem(sys.modules, "discord.app_commands.commands", fake_commands_module)
+    monkeypatch.setitem(sys.modules, "discord.app_commands.decorators", fake_decorators_module)
+
+    sys.modules.pop("src.discord_compat", None)
+    sys.modules.pop("src.preflight", None)
+    preflight = importlib.import_module("src.preflight")
+
+    try:
+        preflight._ensure_discord_sinks_available()
+    finally:
+        sys.modules.pop("src.preflight", None)
+
+    import discord
+
+    assert hasattr(discord, "app_commands")
+    assert discord.app_commands.Command is _FakeCommand
+    assert discord.app_commands.describe is _describe
+    assert discord.app_commands.guild_only is _guild_only
+
+    assert hasattr(discord.enums, "Locale")
+    assert discord.enums.Locale.american_english.value == "en-US"
+    assert discord.enums.AppCommandOptionType is fake_enums.SlashCommandOptionType
+    assert discord.enums.AppCommandType.chat_input.value == 1
+    assert discord.enums.AppCommandPermissionType.role.value == 1


### PR DESCRIPTION
## Summary
- add a compatibility module that backfills missing py-cord app command helpers, enums, and flags
- use the new helper to initialize the command tree during preflight and bot startup
- extend preflight tests to exercise the compatibility layer, including py-cord style stubs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e08e12b260832faf7de9be0564d1d9