### PR TITLE
Normalize Pycord slash command annotations

### DIFF
--- a/src/discord_bot.py
+++ b/src/discord_bot.py
@@ -19,6 +19,8 @@ from .discord_compat import ensure_app_commands_ready
 ensure_app_commands_ready(raise_on_failure=True)
 from discord import app_commands
 
+_InteractionResponded = getattr(discord, "InteractionResponded", RuntimeError)
+
 _LOGGER = get_logger(__name__)
 
 
@@ -81,6 +83,10 @@ class DiscordAssistantBot(commands.Bot):
         if self._commands_synced:
             return
 
+        tree = getattr(self, "tree", None)
+        if tree is None:  # pragma: no cover - defensive guard
+            return
+
         if self.config_data.discord.guild_ids:
             for guild_id in self.config_data.discord.guild_ids:
                 guild = discord.Object(id=guild_id)
@@ -88,8 +94,6 @@ class DiscordAssistantBot(commands.Bot):
                 await tree.sync(guild=guild)
         else:
             await tree.sync()
-
-        self._commands_synced = True
 
         self._commands_synced = True
 
@@ -104,26 +108,34 @@ class DiscordAssistantBot(commands.Bot):
             try:
                 await self._reset_channel(interaction.channel_id)
             except RuntimeError as exc:
-                await interaction.response.send_message(str(exc), ephemeral=True)
+                await self._send_interaction_message(
+                    interaction, str(exc), ephemeral=True
+                )
                 return
-            await interaction.response.send_message(
-                "Conversation history cleared for this channel."
+            await self._send_interaction_message(
+                interaction, "Conversation history cleared for this channel."
             )
 
         async def ask_handler(interaction: discord.Interaction, question: str) -> None:
-            await interaction.response.defer(thinking=True)
+            await self._defer_interaction(interaction)
             try:
                 reply = await self._ask_channel(interaction.channel_id, question)
             except RuntimeError as exc:
-                await interaction.followup.send(str(exc), ephemeral=True)
+                await self._send_interaction_message(
+                    interaction, str(exc), ephemeral=True, prefer_followup=True
+                )
                 return
-            await interaction.followup.send(reply)
+            await self._send_interaction_message(
+                interaction, reply, prefer_followup=True
+            )
 
         async def join_handler(interaction: discord.Interaction) -> None:
             try:
                 voice_client = await self.voice_session.join(interaction)
             except RuntimeError as exc:
-                await interaction.response.send_message(str(exc), ephemeral=True)
+                await self._send_interaction_message(
+                    interaction, str(exc), ephemeral=True
+                )
                 return
 
             await self._initialize_voice_state(voice_client, interaction.channel_id)
@@ -136,8 +148,8 @@ class DiscordAssistantBot(commands.Bot):
                 on_transcription,
                 timeout=5.0,
             )
-            await interaction.response.send_message(
-                f"Joined voice channel {voice_client.channel.name}."
+            await self._send_interaction_message(
+                interaction, f"Joined voice channel {voice_client.channel.name}."
             )
 
         async def leave_handler(interaction: discord.Interaction) -> None:
@@ -145,26 +157,51 @@ class DiscordAssistantBot(commands.Bot):
             if voice_client and voice_client.channel:
                 await self._cleanup_voice_state(voice_client.channel.id)
             await self.voice_session.leave(interaction)
-            await interaction.response.send_message("Disconnected from voice channel.")
+            await self._send_interaction_message(
+                interaction, "Disconnected from voice channel."
+            )
 
         async def say_handler(interaction: discord.Interaction, text: str) -> None:
             voice_client = getattr(interaction.guild, "voice_client", None)
             if not voice_client:
-                await interaction.response.send_message(
+                await self._send_interaction_message(
+                    interaction,
                     "I need to be in a voice channel to speak. Use the /join command first.",
                     ephemeral=True,
                 )
                 return
             await self.voice_session.speak(voice_client, text)
-            await interaction.response.send_message("Playing synthesized speech.")
+            await self._send_interaction_message(
+                interaction, "Playing synthesized speech."
+            )
 
         async def status_handler(interaction: discord.Interaction) -> None:
-            await interaction.response.send_message(embed=self._build_status_embed())
+            await self._send_interaction_message(
+                interaction, embed=self._build_status_embed()
+            )
 
         if self._is_pycord:
             slash_kwargs: Dict[str, Any] = {}
             if self.config_data.discord.guild_ids:
                 slash_kwargs["guild_ids"] = self.config_data.discord.guild_ids
+
+            def normalize_pycord_annotations(
+                func: Any, option_types: Optional[Dict[str, Any]] = None
+            ) -> None:
+                annotations = getattr(func, "__annotations__", None)
+                if not annotations:
+                    return
+
+                ctx_type = getattr(discord, "ApplicationContext", None)
+                if ctx_type and annotations.get("ctx"):
+                    annotations["ctx"] = ctx_type
+
+                if not option_types:
+                    return
+
+                for name, value in option_types.items():
+                    if name in annotations:
+                        annotations[name] = value
 
             reset_decorator = self.slash_command(
                 name="reset",
@@ -177,6 +214,18 @@ class DiscordAssistantBot(commands.Bot):
                 interaction = getattr(ctx, "interaction", ctx)
                 await reset_handler(interaction)
 
+            normalize_pycord_annotations(reset_command)
+
+            option_decorator = getattr(discord, "option", None)
+
+            def decorate_question_option(func: Any) -> Any:
+                if callable(option_decorator):
+                    return option_decorator(
+                        "question",
+                        description="The question you want to ask the assistant",
+                    )(func)
+                return func
+
             ask_decorator = self.slash_command(
                 name="ask",
                 description="Ask the assistant a question",
@@ -184,11 +233,14 @@ class DiscordAssistantBot(commands.Bot):
             )
 
             @ask_decorator
+            @decorate_question_option
             async def ask_command(
                 ctx: discord.ApplicationContext, question: str
             ) -> None:
                 interaction = getattr(ctx, "interaction", ctx)
                 await ask_handler(interaction, question)
+
+            normalize_pycord_annotations(ask_command, {"question": str})
 
             join_decorator = self.slash_command(
                 name="join",
@@ -201,6 +253,8 @@ class DiscordAssistantBot(commands.Bot):
                 interaction = getattr(ctx, "interaction", ctx)
                 await join_handler(interaction)
 
+            normalize_pycord_annotations(join_command)
+
             leave_decorator = self.slash_command(
                 name="leave",
                 description="Disconnect the assistant from the voice channel",
@@ -212,6 +266,16 @@ class DiscordAssistantBot(commands.Bot):
                 interaction = getattr(ctx, "interaction", ctx)
                 await leave_handler(interaction)
 
+            normalize_pycord_annotations(leave_command)
+
+            def decorate_text_option(func: Any) -> Any:
+                if callable(option_decorator):
+                    return option_decorator(
+                        "text",
+                        description="What you want the assistant to say",
+                    )(func)
+                return func
+
             say_decorator = self.slash_command(
                 name="say",
                 description="Have the assistant speak in the connected voice channel",
@@ -219,11 +283,14 @@ class DiscordAssistantBot(commands.Bot):
             )
 
             @say_decorator
+            @decorate_text_option
             async def say_command(
                 ctx: discord.ApplicationContext, text: str
             ) -> None:
                 interaction = getattr(ctx, "interaction", ctx)
                 await say_handler(interaction, text)
+
+            normalize_pycord_annotations(say_command, {"text": str})
 
             status_decorator = self.slash_command(
                 name="status",
@@ -235,6 +302,8 @@ class DiscordAssistantBot(commands.Bot):
             async def status_command(ctx: discord.ApplicationContext) -> None:
                 interaction = getattr(ctx, "interaction", ctx)
                 await status_handler(interaction)
+
+            normalize_pycord_annotations(status_command)
 
             return
 
@@ -338,6 +407,71 @@ class DiscordAssistantBot(commands.Bot):
         @self.command(name="status", help="Show configuration details for the assistant")
         async def status_prefix(ctx: commands.Context) -> None:
             await ctx.send(embed=self._build_status_embed())
+
+    async def _defer_interaction(self, interaction: discord.Interaction) -> None:
+        response = getattr(interaction, "response", None)
+        if response is None:
+            return
+
+        defer = getattr(response, "defer", None)
+        if not callable(defer):  # pragma: no cover - defensive guard
+            return
+
+        try:
+            await defer(thinking=True)
+        except TypeError:
+            await defer()
+
+    async def _send_interaction_message(
+        self,
+        interaction: discord.Interaction,
+        content: Optional[str] = None,
+        *,
+        ephemeral: bool = False,
+        prefer_followup: bool = False,
+        embed: Optional[discord.Embed] = None,
+    ) -> None:
+        kwargs: Dict[str, Any] = {}
+        if content is not None:
+            kwargs["content"] = content
+        if embed is not None:
+            kwargs["embed"] = embed
+        if not kwargs:
+            return
+
+        response = getattr(interaction, "response", None)
+        followup = getattr(interaction, "followup", None)
+
+        async def _send_via_followup() -> bool:
+            if followup is None or not hasattr(followup, "send"):
+                return False
+            await followup.send(**kwargs, ephemeral=ephemeral)
+            return True
+
+        if prefer_followup:
+            if await _send_via_followup():
+                return
+
+        if response is not None:
+            is_done = getattr(response, "is_done", None)
+            if callable(is_done) and is_done():
+                if await _send_via_followup():
+                    return
+            send_message = getattr(response, "send_message", None)
+            if callable(send_message):
+                try:
+                    await send_message(ephemeral=ephemeral, **kwargs)
+                    return
+                except _InteractionResponded:
+                    if await _send_via_followup():
+                        return
+
+        if await _send_via_followup():
+            return
+
+        channel = getattr(interaction, "channel", None)
+        if channel is not None and hasattr(channel, "send"):
+            await channel.send(**kwargs)
 
     async def _reset_channel(self, channel_id: Optional[int]) -> None:
         if channel_id is None:


### PR DESCRIPTION
## Summary
- resolve Pycord slash command forward annotations to runtime types so option introspection no longer raises `issubclass` errors
- normalize question and text option hints to `str` while keeping optional metadata decorators available

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0a5966a00832fa06fd384a7ea5f57