### PR TITLE
Handle Discord 4006 voice reconnects

### DIFF
--- a/tests/test_voice_session.py
+++ b/tests/test_voice_session.py
@@ -31,7 +31,7 @@ def test_join_retries_with_fresh_voice_session_when_invalidated(monkeypatch):
 
     async def fake_connect(*, reconnect: bool):
         connect_calls.append(reconnect)
-        if reconnect:
+        if len(connect_calls) == 1:
             raise discord.errors.ConnectionClosed(_DummySocket(), shard_id=None, code=4006)
         return _DummyVoiceClient(channel)
 
@@ -46,7 +46,7 @@ def test_join_retries_with_fresh_voice_session_when_invalidated(monkeypatch):
     voice_client = _EVENT_LOOP.run_until_complete(session.join(ctx))
 
     assert isinstance(voice_client, _DummyVoiceClient)
-    assert connect_calls == [True, False]
+    assert connect_calls == [False, False]
 
 
 def test_join_raises_helpful_error_when_voice_gateway_closes(monkeypatch):


### PR DESCRIPTION
## Summary
- force fresh Discord voice handshakes when establishing a voice session to avoid websocket close code 4006
- wait briefly and fully clean up the failed voice client before retrying the join
- update the voice session tests to cover the new reconnect strategy

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2b972e7a4832f8f908210e11af2fb